### PR TITLE
Added edit case for comments_controller_spec.rb

### DIFF
--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe CommentsController do
@@ -11,9 +13,16 @@ RSpec.describe CommentsController do
   describe 'index' do
     it 'renders load_comments view' do
       get :index, xhr: true, format: :js, params: {task_id: task.id}
-      expect(response).to render_template("load_comments")
+      expect(response).to render_template('load_comments')
     end
 
+    it 'answers with HTTP 200 OK' do
+      get :index, xhr: true, format: :js, params: {task_id: task.id}
+      expect(response).to have_http_status :ok
+    end
+  end
+
+  describe 'edit' do
     it 'answers with HTTP 200 OK' do
       get :index, xhr: true, format: :js, params: {task_id: task.id}
       expect(response).to have_http_status :ok


### PR DESCRIPTION
While this issue was only reported for the load_comments case, the same issue was present for editing comments.

For that reason, there should be another test case to at least check the rendering.